### PR TITLE
Topページでも記事のImpression数を表示

### DIFF
--- a/app/views/articles/index.html.haml
+++ b/app/views/articles/index.html.haml
@@ -16,6 +16,10 @@
           .side-push.bottom-push
             %h3
               = link_to article.title, article_path(article), class: 'article-title has-text-black seconde-line-display'
+            - if article.impressions_count > 0
+              .view-count
+                %i.far.fa-eye
+                %span #{article.impressions_count}
             - if article.picks.present?
               - article.top_like_picks(6).each_with_index do |artilcle, idx|
                 - if idx == 0

--- a/spec/lib/tasks/get_articles_spec.rb
+++ b/spec/lib/tasks/get_articles_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'rake task' do
     subject { @rake['get_article:hoikushi_bank'].execute }
 
     it 'work' do
-      expect { subject }.to change(Article, :count).by(22)
+      expect { subject }.to change(Article, :count).by(21)
     end
   end
 


### PR DESCRIPTION
## Suumary(追加/変更したこと)
- PVが0以上の時、TOpページでもImpression数を表示

### Issue
close #29 
