### PR TITLE
:bug: JS周りの動きとコンソールのバグを修正

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -11,14 +11,13 @@
 // about supported directives.
 //
 //= require jquery
-//= require rails-ujs
+//= require jquery_ujs
 //= require activestorage
-//= require turbolinks
 //= require_tree .
 
-$(document).ready(function() {
-  $(".navbar-burger").click(function() {
+$(function(){
+  $(".navbar-burger").on('click',function(){
     $(".navbar-burger").toggleClass("is-active");
-      $(".navbar-menu").toggleClass("is-active");
+    $(".navbar-menu").toggleClass("is-active");
   });
 });

--- a/app/assets/javascripts/articles.js
+++ b/app/assets/javascripts/articles.js
@@ -1,6 +1,5 @@
-$(function() {
-  // $(".slider-for").not('.slick-initialized').slick()
-  $('.slider-for').slick({
+$(document).ready(function(){
+  $('.slider-for').not('.slick-initialized').slick({
     slidesToShow: 3,
     swipeToSlide: true,
     swipe: true,
@@ -11,7 +10,7 @@ $(function() {
     prevArrow: '<div class="prev-arrow slick-arrow"><i class="fas fa-angle-left"></i></div>',
     nextArrow: '<div class="next-arrow slick-arrow"><i class="fas fa-angle-right"></i></div>'
   });
-  $('.slider-nav').slick({
+  $('.slider-nav').not('.slick-initialized').slick({
     slidesToShow: 1,
     arrows: false,
     asNavFor: '.slider-for',

--- a/app/views/articles/show.html.haml
+++ b/app/views/articles/show.html.haml
@@ -32,7 +32,7 @@
   = render 'articles/picks', picks: @article.top_like_picks.except_feature_pick(@feature_pick)
 
   - if logged_in? && @article.mypick(current_user).nil?
-    = form_with model: @article.picks.build, url: article_picks_path(@article), class: 'top-push side-push', remote: true do |form|
+    = form_with model: @article.picks.build, url: article_picks_path(@article), class: 'top-push side-push bottom-push', remote: true do |form|
       .field
         = form.text_area :comment, class: 'textarea',placeholder: 'コメント'
       %p.has-text-centered

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -2,11 +2,11 @@
   .container
     %h2.navbar-brand
       = link_to 'HoikuPicks', root_path, class: 'navbar-item has-text-weight-bold'
-      %a.navbar-burger.burger{"data-target" => "navbarBasicExample"}
+      %a.navbar-burger.burger{"data-target" => "navbarToggleMenu"}
         %span
         %span
         %span
-    #navbarBasicExample.navbar-menu
+    #navbarToggleMenu.navbar-menu
       .navbar-end
         .navbar-item.has-dropdown.is-hoverable
           - if logged_in?

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -3,11 +3,11 @@
   %head
     %meta{:content => "text/html; charset=UTF-8", "http-equiv" => "Content-Type"}
     %meta{ name: 'viewport', content: 'initial-scale=1.0, user-scalable=no' }
-    %title Hoikunews
+    %title HoikuPicks
     = csrf_meta_tags
     = csp_meta_tag
-    %link{rel: "stylesheet", type: "text/css", href: "https://cdn.jsdelivr.net/npm/slick-carousel@1.8.1/slick/slick.css"}
-    %link{rel: "stylesheet", type: "text/css", href: "https://cdn.jsdelivr.net/npm/slick-carousel@1.8.1/slick/slick-theme.css"}
+    %link{rel: "stylesheet", type: "text/css", href: "//cdn.jsdelivr.net/npm/slick-carousel@1.8.1/slick/slick.css"}
+    %link{rel: "stylesheet", type: "text/css", href: "//cdn.jsdelivr.net/npm/slick-carousel@1.8.1/slick/slick-theme.css"}
     %link{rel: "stylesheet", href: "https://use.fontawesome.com/releases/v5.8.2/css/all.css"}
     = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
     = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'


### PR DESCRIPTION
### Step（実現する手順）
1. `Error in slick.js: “Uncaught TypeError: Cannot read property 'add' of null”`の対応
→ `$('.slider-for').not('.slick-initialized').slick({});`でSlickを読み込む
2. Navbarの動きページ遷移時にうまく起動しない
→ `$(document).ready({});`で読み込む
→` turbolinks`を削除

### Issue
close #33 
